### PR TITLE
Keep third note in second inversion triads.

### DIFF
--- a/src/musiclib.cpp
+++ b/src/musiclib.cpp
@@ -87,7 +87,6 @@ struct chord get_chord(int root_note, int type, int inversion, int voicing){
             third_note += 12;
             int tmp = root_note;
             root_note = fifth_note;
-            third_note = fifth_note;
             fifth_note = third_note;
             third_note = tmp;
 		}


### PR DESCRIPTION
Third note was getting set to fifth, then fifth was getting set to third (now fifth), so fifth was not actually updating. Consequently, the third of the triad was being lost, making major, minor, and suspended triads sound all the same.